### PR TITLE
Create CNAME for harbour-project.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+harbour-project.org


### PR DESCRIPTION
When accessing http://harbour-project.org, the browser gets redirected (HTTP 302) to harbour.github.io.

It the intention to have the harbour-project.org as the main address for the project, the DNS records should be configured for that. The CNAME file here in the repository is one step.

The DNS should be configured according to [this doc](https://help.github.com/articles/setting-up-a-custom-domain-with-github-pages#apex-domains).

And even if a user access harbor.github.io, it should get to harbour-project.org.
