### PR TITLE
Add a reference to OOHG project

### DIFF
--- a/forks.md
+++ b/forks.md
@@ -71,4 +71,9 @@ binary form only, making it difficult/impossible to find out what was the exact
 source code / patches they were built from. In practice it means that general
 Harbour support forums can't help with issues.
 
+* [OOHG] (https://oohg.github.io/)
+
+Another MiniGUI fork that implements a full OOP model without altered Harbour
+sources nor overlapping libraries. It has its own active support group.
+
 </div>


### PR DESCRIPTION
 This patch adds to "Fork" page a reference to OOHG project.